### PR TITLE
Update node.js support to `>=20`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
         node-version:
           - 20
           - 22
+          - 24
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18
           - 20
           - 22
     steps:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"default": "./distribution/main.js"
 	},
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	},
 	"scripts": {
 		"prepare": "husky",


### PR DESCRIPTION
Removes support for node.js 18 (Hydrogen) and adds node.js 24 (next LTS) to the test matrix.